### PR TITLE
Add demo UI with mock agent backend

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,54 @@
+# E.Factorial Agent Demo
+
+This directory contains a lightweight, static demo that showcases how the E.Factorial agent surfaces LangGraph pipeline recommendations. The mock frontend renders a chatbot UI, visual pipeline DAG, and the explanation panel for three scripted scenarios.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 18 or newer
+- A modern browser (Chrome, Edge, Firefox, or Safari)
+
+## Available scenarios
+
+| ID | Title | Description |
+| --- | --- | --- |
+| `data_cleanup` | Marketing Ops: Clean Campaign Responses | Deduplicates and standardizes campaign data before QA. |
+| `research_brief` | Analyst: Compile AI Policy Brief | Aggregates recent coverage into a summarized policy brief. |
+| `customer_support` | Support: Resolve Escalated Ticket | Walks through an escalation runbook with human approval. |
+
+## Run the mock backend
+
+The mock backend exposes the same endpoints expected from the real agent service: `/api/intent`, `/api/pipeline`, `/api/explanation`, and `/api/decision`.
+
+```bash
+node server.js
+```
+
+By default, the server listens on <http://localhost:4173>. You can override the port with `PORT=5000 node server.js` if desired.
+
+## Launch the demo UI
+
+Open a new terminal tab and use any static file server to serve `index.html`. Two easy options:
+
+### Option 1: Node HTTP server (no install)
+
+```bash
+npx serve@14 .
+```
+
+### Option 2: Python (built-in)
+
+```bash
+python -m http.server 4172
+```
+
+Then visit the URL printed by the static server (for example <http://localhost:4172/demo/index.html>). Make sure the `server.js` mock backend continues running so the UI can fetch responses.
+
+## How the demo works
+
+1. Select one of the scripted scenarios from the dropdown.
+2. The conversation panel displays the opening agent message.
+3. Type a prompt and press **Send**. The frontend calls `/api/intent` to mock intent parsing, then requests `/api/pipeline` and `/api/explanation` based on that intent.
+4. The returned LangGraph pipeline is rendered as a DAG using D3.js, while the explanation section summarizes key decisions and risks.
+5. Use **Approve Pipeline** or **Request Changes** to notify the mock backend of your decision.
+
+The demo is intentionally simple so that product teams can iterate on UI flows before connecting to the live agent service.

--- a/demo/app.js
+++ b/demo/app.js
@@ -1,0 +1,278 @@
+const state = {
+  scenarioId: null,
+  history: [],
+  pipeline: null,
+  explanation: null,
+};
+
+const conversationEl = document.getElementById('conversation');
+const scenarioSelectEl = document.getElementById('scenarioSelect');
+const chatFormEl = document.getElementById('chatForm');
+const messageInputEl = document.getElementById('messageInput');
+const explanationEl = document.getElementById('explanation');
+const approveButtonEl = document.getElementById('approveButton');
+const requestChangesButtonEl = document.getElementById('requestChangesButton');
+const toastEl = document.getElementById('toast');
+
+const pipelineSvg = d3.select('#pipelineGraph');
+const svgGroup = pipelineSvg.append('g');
+const zoom = d3.zoom().on('zoom', (event) => {
+  svgGroup.attr('transform', event.transform);
+});
+pipelineSvg.call(zoom);
+
+async function fetchJSON(url, options = {}) {
+  const response = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Request failed (${response.status}): ${text}`);
+  }
+  return response.json();
+}
+
+function renderMessage({ role, content }) {
+  const messageEl = document.createElement('div');
+  messageEl.className = `message ${role}`;
+  messageEl.textContent = content;
+  conversationEl.appendChild(messageEl);
+  conversationEl.scrollTop = conversationEl.scrollHeight;
+}
+
+function resetConversation(script) {
+  conversationEl.innerHTML = '';
+  state.history = [];
+  script.forEach((message) => {
+    state.history.push(message);
+    renderMessage(message);
+  });
+}
+
+function showToast(message) {
+  toastEl.textContent = message;
+  toastEl.classList.add('show');
+  setTimeout(() => toastEl.classList.remove('show'), 2200);
+}
+
+function renderExplanation(explanation) {
+  explanationEl.innerHTML = '';
+
+  const summary = document.createElement('p');
+  summary.textContent = explanation.summary;
+  explanationEl.appendChild(summary);
+
+  if (explanation.decisions?.length) {
+    const decisionsHeading = document.createElement('h3');
+    decisionsHeading.textContent = 'Key Decisions';
+    explanationEl.appendChild(decisionsHeading);
+
+    const list = document.createElement('ul');
+    explanation.decisions.forEach((decision) => {
+      const item = document.createElement('li');
+      item.textContent = decision;
+      list.appendChild(item);
+    });
+    explanationEl.appendChild(list);
+  }
+
+  if (explanation.risks?.length) {
+    const risksHeading = document.createElement('h3');
+    risksHeading.textContent = 'Risks & Mitigations';
+    explanationEl.appendChild(risksHeading);
+
+    const list = document.createElement('ul');
+    explanation.risks.forEach((risk) => {
+      const item = document.createElement('li');
+      item.textContent = risk;
+      list.appendChild(item);
+    });
+    explanationEl.appendChild(list);
+  }
+}
+
+function renderPipeline(pipeline) {
+  const width = pipelineSvg.node().clientWidth || 600;
+  const height = pipelineSvg.node().clientHeight || 400;
+
+  pipelineSvg.attr('viewBox', `0 0 ${width} ${height}`);
+
+  svgGroup.selectAll('*').remove();
+
+  const simulation = d3
+    .forceSimulation(pipeline.nodes)
+    .force('link', d3.forceLink(pipeline.edges).id((d) => d.id).distance(160))
+    .force('charge', d3.forceManyBody().strength(-320))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+    .stop();
+
+  for (let i = 0; i < 120; i += 1) {
+    simulation.tick();
+  }
+
+  const link = svgGroup
+    .selectAll('line')
+    .data(pipeline.edges)
+    .enter()
+    .append('line')
+    .attr('stroke', '#64748b')
+    .attr('stroke-width', 2)
+    .attr('marker-end', 'url(#arrowhead)');
+
+  const node = svgGroup
+    .selectAll('g.node')
+    .data(pipeline.nodes)
+    .enter()
+    .append('g')
+    .attr('class', 'node')
+    .attr('transform', (d) => `translate(${d.x},${d.y})`);
+
+  node
+    .append('rect')
+    .attr('width', 160)
+    .attr('height', 60)
+    .attr('x', -80)
+    .attr('y', -30)
+    .attr('rx', 14)
+    .attr('fill', (d) => d.color || '#1d4ed8')
+    .attr('opacity', 0.85)
+    .attr('stroke', '#e2e8f0')
+    .attr('stroke-width', 1.5);
+
+  node
+    .append('text')
+    .attr('text-anchor', 'middle')
+    .attr('dominant-baseline', 'middle')
+    .attr('fill', '#f8fafc')
+    .attr('font-weight', 600)
+    .text((d) => d.label);
+
+  const defs = svgGroup.append('defs');
+  defs
+    .append('marker')
+    .attr('id', 'arrowhead')
+    .attr('viewBox', '0 -5 10 10')
+    .attr('refX', 28)
+    .attr('refY', 0)
+    .attr('markerWidth', 8)
+    .attr('markerHeight', 8)
+    .attr('orient', 'auto')
+    .append('path')
+    .attr('d', 'M0,-5L10,0L0,5')
+    .attr('fill', '#64748b');
+
+  link
+    .attr('x1', (d) => d.source.x)
+    .attr('y1', (d) => d.source.y)
+    .attr('x2', (d) => d.target.x)
+    .attr('y2', (d) => d.target.y);
+}
+
+function disableInput(disabled) {
+  messageInputEl.disabled = disabled;
+  messageInputEl.placeholder = disabled ? 'Waiting for agent response…' : 'Ask the agent…';
+}
+
+async function loadScenarios() {
+  try {
+    const data = await fetchJSON('/api/scenarios');
+    scenarioSelectEl.innerHTML = '';
+    data.scenarios.forEach((scenario) => {
+      const option = document.createElement('option');
+      option.value = scenario.id;
+      option.textContent = scenario.title;
+      scenarioSelectEl.appendChild(option);
+    });
+    if (data.scenarios.length > 0) {
+      scenarioSelectEl.value = data.scenarios[0].id;
+      selectScenario(data.scenarios[0].id);
+    }
+  } catch (error) {
+    console.error(error);
+    showToast('Unable to load scenarios. Start the dev server?');
+  }
+}
+
+async function selectScenario(scenarioId) {
+  try {
+    const data = await fetchJSON(`/api/scenarios/${scenarioId}`);
+    state.scenarioId = scenarioId;
+    resetConversation(data.script);
+    renderPipeline(data.pipeline);
+    renderExplanation(data.explanation);
+  } catch (error) {
+    console.error(error);
+    showToast('Failed to load the scenario.');
+  }
+}
+
+async function handleChatSubmit(event) {
+  event.preventDefault();
+  if (!state.scenarioId) return;
+
+  const message = messageInputEl.value.trim();
+  if (!message) return;
+
+  const userMessage = { role: 'user', content: message };
+  state.history.push(userMessage);
+  renderMessage(userMessage);
+
+  disableInput(true);
+  messageInputEl.value = '';
+
+  try {
+    const intentResponse = await fetchJSON('/api/intent', {
+      method: 'POST',
+      body: JSON.stringify({ scenarioId: state.scenarioId, message }),
+    });
+    const agentMessage = { role: 'agent', content: intentResponse.reply };
+    state.history.push(agentMessage);
+    renderMessage(agentMessage);
+
+    const [pipelineResponse, explanationResponse] = await Promise.all([
+      fetchJSON('/api/pipeline', {
+        method: 'POST',
+        body: JSON.stringify({ scenarioId: state.scenarioId, intent: intentResponse.intent }),
+      }),
+      fetchJSON('/api/explanation', {
+        method: 'POST',
+        body: JSON.stringify({ scenarioId: state.scenarioId, intent: intentResponse.intent }),
+      }),
+    ]);
+
+    renderPipeline(pipelineResponse.pipeline);
+    renderExplanation(explanationResponse.explanation);
+  } catch (error) {
+    console.error(error);
+    showToast('Agent service is unavailable.');
+  } finally {
+    disableInput(false);
+  }
+}
+
+function notifyDecision(decision) {
+  if (!state.scenarioId) return;
+  fetchJSON('/api/decision', {
+    method: 'POST',
+    body: JSON.stringify({ scenarioId: state.scenarioId, decision }),
+  })
+    .then((response) => {
+      showToast(response.message);
+    })
+    .catch((error) => {
+      console.error(error);
+      showToast('Failed to record decision.');
+    });
+}
+
+scenarioSelectEl.addEventListener('change', (event) => {
+  selectScenario(event.target.value);
+});
+
+chatFormEl.addEventListener('submit', handleChatSubmit);
+approveButtonEl.addEventListener('click', () => notifyDecision('approve'));
+requestChangesButtonEl.addEventListener('click', () => notifyDecision('request_changes'));
+
+disableInput(true);
+loadScenarios().finally(() => disableInput(false));

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>E.Factorial Agent Demo</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js" integrity="sha512-e7PoR1N0DpSL/ij9uRNGU0TA7yDfVG/0PsGUAts2sYg6by5PAH8Nx48fG29Pgqpt9fEHHSXxT+xedd9tFHY1VQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+</head>
+<body>
+  <header>
+    <h1>E.Factorial Agent Demo</h1>
+    <p>Select a scripted scenario and chat with the agent to see the recommended LangGraph pipeline and explanation.</p>
+  </header>
+
+  <main>
+    <section class="sidebar">
+      <label for="scenarioSelect">Scenario</label>
+      <select id="scenarioSelect"></select>
+      <div class="conversation" id="conversation"></div>
+      <form id="chatForm">
+        <input type="text" id="messageInput" placeholder="Ask the agent..." required />
+        <button type="submit">Send</button>
+      </form>
+      <div class="actions">
+        <button id="approveButton" class="primary">Approve Pipeline</button>
+        <button id="requestChangesButton" class="secondary">Request Changes</button>
+      </div>
+    </section>
+
+    <section class="content">
+      <div class="panel">
+        <h2>Pipeline DAG</h2>
+        <svg id="pipelineGraph" role="img" aria-label="LangGraph pipeline diagram"></svg>
+      </div>
+      <div class="panel explanation">
+        <h2>Agent Explanation</h2>
+        <div id="explanation"></div>
+      </div>
+    </section>
+  </main>
+
+  <div id="toast" role="status" aria-live="polite"></div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/demo/server.js
+++ b/demo/server.js
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+const http = require('http');
+const { URL } = require('url');
+
+const PORT = process.env.PORT || 4173;
+
+const scenarios = {
+  data_cleanup: {
+    id: 'data_cleanup',
+    title: 'Marketing Ops: Clean Campaign Responses',
+    script: [
+      { role: 'agent', content: 'Hi! I can help plan the clean-up pipeline. What do you need?' },
+    ],
+    pipeline: {
+      nodes: [
+        { id: 'ingest', label: 'Load Raw Sheet', color: '#0ea5e9' },
+        { id: 'dedupe', label: 'Deduplicate Leads', color: '#6366f1' },
+        { id: 'standardize', label: 'Standardize Fields', color: '#7c3aed' },
+        { id: 'qa', label: 'QA Summary', color: '#e11d48' },
+      ],
+      edges: [
+        { source: 'ingest', target: 'dedupe' },
+        { source: 'dedupe', target: 'standardize' },
+        { source: 'standardize', target: 'qa' },
+      ],
+    },
+    explanation: {
+      summary: 'The agent recommends loading the sheet, removing duplicates, standardizing column formats, and summarizing QA findings.',
+      decisions: [
+        'Use spreadsheet loader for quick ingestion.',
+        'Apply fuzzy match deduplication on email + company.',
+        'Normalize country/state using locale tables.',
+      ],
+      risks: [
+        'Manual overrides may be needed for edge-case locales.',
+      ],
+    },
+  },
+  research_brief: {
+    id: 'research_brief',
+    title: 'Analyst: Compile AI Policy Brief',
+    script: [
+      { role: 'agent', content: 'Hello researcher! Ready to assemble a policy brief when you are.' },
+    ],
+    pipeline: {
+      nodes: [
+        { id: 'ingest', label: 'Search Recent News', color: '#14b8a6' },
+        { id: 'cluster', label: 'Cluster Findings', color: '#f97316' },
+        { id: 'summarize', label: 'Summarize Themes', color: '#a855f7' },
+        { id: 'brief', label: 'Draft Brief', color: '#f43f5e' },
+      ],
+      edges: [
+        { source: 'ingest', target: 'cluster' },
+        { source: 'cluster', target: 'summarize' },
+        { source: 'summarize', target: 'brief' },
+      ],
+    },
+    explanation: {
+      summary: 'Recommended pipeline pulls recent coverage, groups similar stories, summarizes each cluster, and drafts the final brief.',
+      decisions: [
+        'Blend web search with knowledge base retrieval.',
+        'Use embedding clustering for thematic grouping.',
+        'Summaries feed into a structured brief template.',
+      ],
+      risks: [
+        'Search API quota must be monitored during peak cycles.',
+      ],
+    },
+  },
+  customer_support: {
+    id: 'customer_support',
+    title: 'Support: Resolve Escalated Ticket',
+    script: [
+      { role: 'agent', content: 'Support engineer here—share the ticket details and I will design a runbook.' },
+    ],
+    pipeline: {
+      nodes: [
+        { id: 'triage', label: 'Intent Triage', color: '#0ea5e9' },
+        { id: 'retrieve', label: 'Retrieve SOP', color: '#facc15' },
+        { id: 'diagnose', label: 'Diagnose Failure', color: '#22c55e' },
+        { id: 'handoff', label: 'Draft Customer Reply', color: '#f97316' },
+      ],
+      edges: [
+        { source: 'triage', target: 'retrieve' },
+        { source: 'retrieve', target: 'diagnose' },
+        { source: 'diagnose', target: 'handoff' },
+      ],
+    },
+    explanation: {
+      summary: 'The runbook triages the issue, retrieves the relevant SOP, runs diagnostics, and drafts a message for the customer.',
+      decisions: [
+        'Intent classifier identifies whether the issue is account, billing, or technical.',
+        'Diagnostic checklist prompts engineer inputs.',
+        'Response generator provides a draft email for review.',
+      ],
+      risks: [
+        'Escalations require human approval before sending.',
+      ],
+    },
+  },
+};
+
+const scenarioList = Object.values(scenarios);
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk) => {
+      data += chunk;
+      if (data.length > 1e6) {
+        req.connection.destroy();
+        reject(new Error('Payload too large'));
+      }
+    });
+    req.on('end', () => {
+      if (!data) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(data));
+      } catch (error) {
+        reject(new Error('Invalid JSON payload'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function writeJSON(res, statusCode, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(payload),
+    'Access-Control-Allow-Origin': '*',
+  });
+  res.end(payload);
+}
+
+function handleIntent({ scenarioId, message }) {
+  const scenario = scenarios[scenarioId];
+  if (!scenario) return { status: 404, body: { error: 'Unknown scenario' } };
+
+  const response = {
+    intent: `${scenarioId}:analyzed`,
+    reply: `I understand the request: "${message}". Here is how I would proceed...`,
+  };
+
+  return { status: 200, body: response };
+}
+
+function handlePipeline({ scenarioId }) {
+  const scenario = scenarios[scenarioId];
+  if (!scenario) return { status: 404, body: { error: 'Unknown scenario' } };
+
+  const pipeline = JSON.parse(JSON.stringify(scenario.pipeline));
+  return { status: 200, body: { pipeline } };
+}
+
+function handleExplanation({ scenarioId }) {
+  const scenario = scenarios[scenarioId];
+  if (!scenario) return { status: 404, body: { error: 'Unknown scenario' } };
+
+  const explanation = JSON.parse(JSON.stringify(scenario.explanation));
+  return { status: 200, body: { explanation } };
+}
+
+function handleDecision({ scenarioId, decision }) {
+  const scenario = scenarios[scenarioId];
+  if (!scenario) return { status: 404, body: { error: 'Unknown scenario' } };
+
+  const verb = decision === 'approve' ? 'approved' : 'flagged for changes';
+  return {
+    status: 200,
+    body: { message: `${scenario.title} ${verb}.` },
+  };
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    });
+    res.end();
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/scenarios') {
+    writeJSON(res, 200, { scenarios: scenarioList.map(({ id, title }) => ({ id, title })) });
+    return;
+  }
+
+  const scenarioMatch = url.pathname.match(/^\/api\/scenarios\/([\w_-]+)$/);
+  if (req.method === 'GET' && scenarioMatch) {
+    const scenarioId = scenarioMatch[1];
+    const scenario = scenarios[scenarioId];
+    if (!scenario) {
+      writeJSON(res, 404, { error: 'Unknown scenario' });
+      return;
+    }
+    writeJSON(res, 200, scenario);
+    return;
+  }
+
+  const requiresBody = ['/api/intent', '/api/pipeline', '/api/explanation', '/api/decision'];
+  if (requiresBody.includes(url.pathname)) {
+    try {
+      const payload = await readRequestBody(req);
+      let response;
+      switch (url.pathname) {
+        case '/api/intent':
+          response = handleIntent(payload);
+          break;
+        case '/api/pipeline':
+          response = handlePipeline(payload);
+          break;
+        case '/api/explanation':
+          response = handleExplanation(payload);
+          break;
+        case '/api/decision':
+          response = handleDecision(payload);
+          break;
+        default:
+          response = { status: 404, body: { error: 'Not found' } };
+      }
+      writeJSON(res, response.status, response.body);
+    } catch (error) {
+      writeJSON(res, 400, { error: error.message });
+    }
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+server.listen(PORT, () => {
+  console.log(`Mock agent backend running on http://localhost:${PORT}`);
+});

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -1,0 +1,234 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  padding: 1.5rem 2rem;
+  background: linear-gradient(120deg, #0f172a, #1e293b);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+}
+
+header p {
+  margin: 0;
+  color: #94a3b8;
+}
+
+main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem 2rem;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  padding: 1.25rem;
+  backdrop-filter: blur(6px);
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  color: #cbd5f5;
+}
+
+select,
+input[type="text"],
+button {
+  font: inherit;
+}
+
+select,
+input[type="text"] {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.65rem 0.9rem;
+  background: rgba(15, 23, 42, 0.4);
+  color: inherit;
+}
+
+select:focus,
+input[type="text"]:focus {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.conversation {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-right: 0.25rem;
+}
+
+.message {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.message.user {
+  align-self: flex-end;
+  background: #4f46e5;
+  color: #f8fafc;
+}
+
+.message.agent {
+  align-self: flex-start;
+  background: rgba(148, 163, 184, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+#chatForm {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+}
+
+#chatForm button {
+  padding: 0.65rem 1.1rem;
+  border-radius: 12px;
+  border: none;
+  background: #38bdf8;
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+#chatForm button:hover {
+  background: #0ea5e9;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.actions .primary,
+.actions .secondary {
+  flex: 1;
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.actions .primary {
+  background: #22c55e;
+  color: #052e16;
+}
+
+.actions .primary:hover {
+  background: #16a34a;
+}
+
+.actions .secondary {
+  background: rgba(148, 163, 184, 0.15);
+  color: inherit;
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+.actions .secondary:hover {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.content {
+  display: grid;
+  grid-template-rows: minmax(320px, 1fr) minmax(200px, auto);
+  gap: 1.5rem;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+#pipelineGraph {
+  width: 100%;
+  height: 100%;
+  min-height: 280px;
+}
+
+#explanation {
+  color: #e2e8f0;
+  line-height: 1.6;
+}
+
+#explanation h3 {
+  margin-top: 1rem;
+}
+
+#toast {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.2);
+  color: #e2e8f0;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+#toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 1024px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    order: 2;
+  }
+
+  .content {
+    order: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a demo web UI that shows the agent chat, pipeline DAG visualiser, and explanation panel
- use D3.js to render the LangGraph pipeline returned from the service endpoints
- include a mock Node.js backend and documentation to run the scripted scenarios locally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5f6e1486483329706a8e1155cb488